### PR TITLE
Added checking for alternative file functionality

### DIFF
--- a/csgo-csmd
+++ b/csgo-csmd
@@ -11,7 +11,7 @@ from typing import Any, Union
 from urllib import request
 from urllib.error import HTTPError
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 class ANSIColors:
@@ -228,8 +228,45 @@ class CSMD:
 
             self.materials.extend([_[-1] for _ in materials])
 
+    def check_material(self, material: str) -> None:
+        if "appended" not in self.materials:
+            self.materials.append("appended")
+        if material not in self.materials:
+            self.materials.append(material)
+
+    def bz2_process(self, url: str, fpath: str, material: str) -> None:
+        try:
+            with request.urlopen(url) as response, \
+                    fpath.with_suffix("").open('wb') as f:
+                print("{0}{1} Decompressing package...{2}"
+                      .format(ANSIColors.bold, ANSIColors.blue, ANSIColors.end))
+                f.write(decompress(response.read()))
+        except HTTPError as err:
+            # We know that we ignore 404 and raise
+            # everything else, though we need to
+            # check for its counterpart
+            self.check_material(material[:-4])
+            HTPPErrorHandler(err).handle()
+                
+    def non_bz2_process(self, url: str, fpath: str, material: str) -> None: 
+        try:
+            with request.urlopen(url) as response, \
+                    fpath.open('wb') as f:
+                # Use shutil to write response on-the-fly
+                copyfileobj(response, f)
+        except HTTPError as err:
+            # We know that we ignore 404 and raise
+            # everything else, though we need to
+            # check for its counterpart
+            self.check_material(material + ".bz2")
+            HTPPErrorHandler(err).handle()
+
     def download_materials(self) -> None:
         for material in self.materials:
+            if material == "appended":
+                print("\n{0}  Processing appened material(s){1}".format(
+                    ANSIColors.green, ANSIColors.end))
+                continue
             print("{0}{1}Requesting {2}{3}".format(
                 ANSIColors.bold, ANSIColors.purple, material, ANSIColors.end))
 
@@ -247,29 +284,9 @@ class CSMD:
 
             # Decompressing on-the-fly, thus with_suffix("")
             if fpath.suffix == ".bz2":
-                try:
-                    with request.urlopen(url) as response, \
-                            fpath.with_suffix("").open('wb') as f:
-                        print("{0}{1} Decompressing bzip2{3}"
-                              .format(ANSIColors.bold, ANSIColors.blue,
-                                      material, ANSIColors.end))
-                        f.write(decompress(response.read()))
-                except HTTPError as err:
-                    HTPPErrorHandler(err).handle()
-                    # We know that we ignore 404 and raise
-                    # everything else, so it's safe to continue
-                    continue
+                self.bz2_process(url, fpath, material)
             else:
-                try:
-                    with request.urlopen(url) as response, \
-                            fpath.open('wb') as f:
-                        # Use shutil to write response on-the-fly
-                        copyfileobj(response, f)
-                except HTTPError as err:
-                    HTPPErrorHandler(err).handle()
-                    # We know that we ignore 404 and raise
-                    # everything else, so it's safe to continue
-                    continue
+                self.non_bz2_process(url, fpath, material)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes when the server asks for a file we don't seem to be able to receive from the given URL (the `condump`) given to us by the server, this change aims to resolve that and check (when a file failed to download) for it's counterpart if it isn't already (planned to be) checked. 

Example:
```
Requesting maps/surf_minuet_njv.bsp
  Not found on the server, skipping 

  Processing appened material
Requesting maps/surf_minuet_njv.bsp.bz2
 Decompressing package...
````